### PR TITLE
Make Multichannel Audio Tools compile on Windows

### DIFF
--- a/audio/dsp/portable/c.bzl
+++ b/audio/dsp/portable/c.bzl
@@ -3,10 +3,13 @@ Defines c_binary, c_library, c_test rules for targets written in C. They are
 like their cc_* counterparts, but compile with C89 standard compatibility.
 """
 
-WARNING_OPTS = [
-    # Suppress "unused function" warnings on `static` functions in .h files.
-    "-Wno-unused-function",
-]
+WARNING_OPTS =  select({
+    "@bazel_tools//src/conditions:windows": [],
+    "//conditions:default": [
+         # Suppress "unused function" warnings on `static` functions in .h files.
+         "-Wno-unused-function",
+    ]
+})
 
 # Build with C89 standard compatibility.
 DEFAULT_C_OPTS = WARNING_OPTS + ["-std=c89"]

--- a/audio/dsp/portable/c.bzl
+++ b/audio/dsp/portable/c.bzl
@@ -7,6 +7,7 @@ WARNING_OPTS =  select({
     "@bazel_tools//src/conditions:windows": [],
     "//conditions:default": [
          # Suppress "unused function" warnings on `static` functions in .h files.
+         # Excluded from Windows due to lack of support by Visual Studio 2017. 
          "-Wno-unused-function",
     ]
 })


### PR DESCRIPTION
We use multichannel-audio-tools with Visual Studio 2017 on Windows. The built-in compiler does not support -Wno-unused-function.

Fixes internal issue b/258070754